### PR TITLE
fix output errors, add details to DE model and contrast usage

### DIFF
--- a/episodes/05-differential-expression.Rmd
+++ b/episodes/05-differential-expression.Rmd
@@ -39,7 +39,7 @@ software package. The [edgeR](https://bioconductor.org/packages/release/bioc/htm
 
 To run `DESeq2` we need to represent our count data as object of the `DESeqDataSet` class.
 The `DESeqDataSet` is an extension of the `SummarizedExperiment` class (see section [Importing and annotating quantified data into R](../episodes/03-import-annotate.Rmd) ) that stores a *design formula* in addition to the count assay(s) and feature (here gene) and sample metadata.
-The *design formula* expresses the variables which will be used in modeling. These are typically the variable of interest (group variable) and other variables you want to account for (e.g., batch effect variables). Objects of the `DESeqDataSet` class can be build from [count matrices](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#countmat), [SummarizedExperiment objects](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#se), [transcript abundance files](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#tximport) or [htseq count files](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#htseq).
+The *design formula* expresses the variables which will be used in modeling. These are typically the variable of interest (group variable) and other variables you want to account for (e.g., batch effect variables). A detailed explanation of *design formulas* and related *design matrices* will follow in the section about [extra exploration of design matrices](../episodes/08-extra-design.Rmd). Objects of the `DESeqDataSet` class can be build from [count matrices](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#countmat), [SummarizedExperiment objects](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#se), [transcript abundance files](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#tximport) or [htseq count files](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#htseq).
 
 ### Load libraries
 
@@ -51,6 +51,7 @@ suppressPackageStartupMessages({
     library(ExploreModelMatrix)
     library(cowplot)
     library(ComplexHeatmap)
+    library(apeglm)
 })
 ```
 
@@ -71,14 +72,14 @@ dds <- DESeq2::DESeqDataSet(se[, se$tissue == "Cerebellum"],
 ::::::::::::::::::::::::::::::::::::: instructor
 The function to generate a `DESeqDataSet` needs to be adapted depending on the input type, e.g, 
 
-```{r}
+```{r, eval=FALSE}
 #From SummarizedExperiment object
-ddsSE <- DESeqDataSet(se, design = ~ cell + dex)
+ddsSE <- DESeqDataSet(se, design = ~ sex + time)
 
 #From count matrix
 dds <- DESeqDataSetFromMatrix(countData = assays(se)$counts,
                               colData = colData(se),
-                              design = ~ condition)
+                              design = ~ sex + time)
 ```
 
 :::::::::::::::::::::::::::::::::::::::::::::::::
@@ -126,7 +127,13 @@ plotDispEsts(dds)
 
 ### Testing
 
-Finally, we can use the `nbinomWaldTest()`function of `DESeq2` to fit a *generalized linear model (GLM)* and compute *log2 fold changes* (synonymous with "GLM coefficients", "beta coefficients" or "effect size"). Log2 fold changes are scaled by their standard error and compared to a standard Normal distribution to calculate *Wald test* p-values. 
+We can use the `nbinomWaldTest()`function of `DESeq2` to fit a *generalized linear model (GLM)* and compute *log2 fold changes* (synonymous with "GLM coefficients", "beta coefficients" or "effect size") corresponding to the variables of the *design matrix*. The *design matrix* is directly related to the *design formular* and automatically derived from it. Assume a design fromular with one variable (`~ treatment`) and two factor level (treatment and control). The mean expression $\mu_{j}$ of a specific gene in sample $j$ will be modeled as following:
+
+$log(μ_j) = β_0 + x_j β_T$,
+
+ with $β_T$ corresponding to the log2 fold change of the treatment group, $x_j$ = 1, if $j$ belongs to the treatment group and $x_j$ = 0, if $j$ belongs to the control group. 
+
+Finally, the estimated log2 fold changes are scaled by their standard error and tested for being significantly different from 0 using the *Wald test*. 
 
 
 ```{r}
@@ -135,6 +142,7 @@ dds <- nbinomWaldTest(dds)
 
 
 ::::::::::::::::::::::::::::::::::::: callout
+### Note
 
 Standard differential expression analysis as performed above is wrapped into a single function, `DESeq()`. Running the first code chunk is equivalent to running the second one:
 
@@ -154,20 +162,18 @@ dds <- nbinomWaldTest(dds)
 
 ## Explore results for specific contrasts
 
-The `results()` function can be used to extract gene-wise statistics, such as log2 fold changes and (adjusted) p-values. By default these statistics will be based on the __last variable__ (reference variable) of the design formular. For comparisons `DESeq2` defines so called contrasts, which refer to the factor levels of the reference variable. By default the first factor level in alphabetical order will be used as *reference level* and the *last level* will be used for comparison. You can explicitly specify the contrast by using the `contrast` or `name` argument of the `results()` function. Names of all available contrasts can be accessed using `resultsNames()`.
+The `results()` function can be used to extract gene-wise test statistics, such as log2 fold changes and (adjusted) p-values. The comparison of interest can be defined using contrasts, which are linear combinations of the model coefficients (equivalent to combinations of columns within the *design matrix*) and thus directly related to the design formular. A detailed explanation of design matrices and how to use them to specify different contrasts of interest can be found in the section on the [exploration of design matrices](../episodes/08-extra-design.Rmd). In the `results()` function a contrast can be represented by the variable of interest (reference variable) and the related level to compare using the `contrast` argument. By default the reference variable will be the __last variable__ of the design formular, the *reference level* will be the first factor level and the *last level* will be used for comparison. You can also explicitly specify a contrast by the `name` argument of the `results()` function. Names of all available contrasts can be accessed using `resultsNames()`.
 
 
 ::::::::::::::::::::::::::::::::::::: challenge 
 
-How can the terms __reference level__ and __last level__ be interpreted? What will be the default __contrast__, __reference level__ and __last level__ when running `results(dds)` for the above example?
+What will be the default __contrast__, __reference level__ and __"last level"__ for comparisons when running `results(dds)` for the example used in this lesson?
 
 *Hint: Check the design formular used to build the object.*
 
 :::::::::::::::::::::::: solution 
 
-The __reference level__ can be interpreted as your experiments __"control group"__ and the __last level__ as __treatment or intervention group__. 
-
-In the above example the last variable of the design formular is `time`. 
+In the lesson example the last variable of the design formular is `time`. 
 The __reference level__ (first in alphabetical order) is `Day0` and the __last level__ is `Day8` 
 
 ```{r}
@@ -179,7 +185,7 @@ No worries, if you had difficulties to identify the default contrast the output 
 :::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-To explore the output of the `results()` function we can use the `summary()` function and order results by significance (p-value).
+To explore the output of the `results()` function we can use the `summary()` function and order results by significance (p-value). Here we assume that we are interested in changes over `time` ("variable of interest"), more specifically genes with differential expression between `Day0` ("reference level") and `Day8` ("level to compare"). The model we used included the `sex` variable (see above). Thus our results will be "corrected" for sex-related differences.
 
 
 ```{r}
@@ -203,9 +209,9 @@ resTime <- results(dds, name = "time_Day8_vs_Day0")
 
 ::::::::::::::::::::::::::::::::::::: challenge 
 
-Explore the DE genes between males and females.
+Explore the DE genes between males and females independent of time.
 
-*Hint: Use `resultsNames()` to get the correct contrast.*
+*Hint: You don't need to fit the GLM again. Use `resultsNames()` to get the correct contrast.*
 
 :::::::::::::::::::::::: solution 
 
@@ -235,7 +241,7 @@ to calculate __adjusted p-values__ (padj) for DE results.
 
 ## Independent Filtering and log-fold shrinkage
 
-We can visualize the results in many ways. A good check is to explore the relationship between log2fold changes, significant results and the genes mean count.
+We can visualize the results in many ways. A good check is to explore the relationship between *log2fold changes*, *significant DE genes* and the *genes mean count*.
 `DESeq2` provides a useful function to do so, `plotMA()`.
 
 ```{r}
@@ -250,11 +256,11 @@ We can *shrink* the log fold changes of these genes with low mean and high dispe
 resTimeLfc <- lfcShrink(dds, coef = "time_Day8_vs_Day0", res = resTime)
 plotMA(resTimeLfc)
 ```
-Shrinkage of log fold changes is useful for visualization and ranking of genes, but for result exploration typically the `indepent_filtering` argument is used to remove lowly expressed genes.
+Shrinkage of log fold changes is useful for visualization and ranking of genes, but for result exploration typically the `independentFiltering` argument is used to remove lowly expressed genes.
 
 ::::::::::::::::::::::::::::::::::::: challenge 
 
-By default `indepent_filtering` is set to `TRUE`. What happens without filtering lowly expressed genes? Use the `summary()` function to compare the results. Most of the lowly expressed genes are not significantly differential expressed (blue in the above MA plots). What could cause the difference in the results then?
+By default `independentFiltering` is set to `TRUE`. What happens without filtering lowly expressed genes? Use the `summary()` function to compare the results. Most of the lowly expressed genes are not significantly differential expressed (blue in the above MA plots). What could cause the difference in the results then?
 
 :::::::::::::::::::::::: solution 
 
@@ -306,7 +312,7 @@ ComplexHeatmap::Heatmap(heatmapData,
 
 Check the heatmap and top DE genes. Do you find something expected/unexpected?
 
-*Hint: Google gene names, if you don't know them.*
+*Hint: Check gene names, if you don't know them.*
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 


### PR DESCRIPTION
More changes related to the DE analysis section:

- added references to section about design matrices
- load `apeglm` to remove the error from the deployment
- added more details and examples on how the GLM is fitted
- added more details about how to specify contrast and how they relate to the design matrix and formular  