### PR TITLE
add missing libraries to setup

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -12,11 +12,11 @@ Additionally, you will also need to install the following packages that will be 
 ```r
 install.packages("BiocManager")
 BiocManager::install(c("tidyverse", "SummarizedExperiment",
-                       "ExploreModelMatrix", "org.Hs.eg.db", "org.Mm.eg.db",
+                       "ExploreModelMatrix", "AnnotationDbi", "org.Hs.eg.db", "org.Mm.eg.db",
                        "DESeq2", "vsn", "ComplexHeatmap", "hgu95av2.db",
                        "RColorBrewer", "hexbin", "cowplot",
                        "clusterProfiler", "enrichplot", "kableExtra",
-                       "msigdbr", "gplots", "ggplot2", "simplifyEnrichment","apeglm"))
+                       "msigdbr", "gplots", "ggplot2", "simplifyEnrichment","apeglm", "microbenchmark"))
 
 ```
 


### PR DESCRIPTION
Noticed there were 2 libraries loaded that are not in the setup installs, so added here.

AnnotationDbi is loaded here https://carpentries-incubator.github.io/bioc-rnaseq/03-import-annotate.html
microbenchmark is loaded here 
https://carpentries-incubator.github.io/bioc-rnaseq/06-gene-set-analysis.html
