### PR TITLE
update 50 packages

### DIFF
--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.17.3"
+  version <- "1.0.2"
   attr(version, "sha") <- NULL
 
   # the project directory

--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -93,13 +93,13 @@
     },
     "BiocManager": {
       "Package": "BiocManager",
-      "Version": "1.30.21",
+      "Version": "1.30.22",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "be203e7eea75514bc1a41c1de39a9bb9"
+      "Hash": "d57e43105a1aa9cb54fdb4629725acb1"
     },
     "BiocParallel": {
       "Package": "BiocParallel",
@@ -230,23 +230,24 @@
     },
     "DT": {
       "Package": "DT",
-      "Version": "0.28",
+      "Version": "0.29",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "crosstalk",
         "htmltools",
         "htmlwidgets",
+        "httpuv",
         "jquerylib",
         "jsonlite",
         "magrittr",
         "promises"
       ],
-      "Hash": "ab745834dfae7eaf71dd0b90f3b66759"
+      "Hash": "02f42b77a951a5ea7c891ef5c187d774"
     },
     "DelayedArray": {
       "Package": "DelayedArray",
-      "Version": "0.26.6",
+      "Version": "0.26.7",
       "Source": "Bioconductor",
       "Requirements": [
         "BiocGenerics",
@@ -260,7 +261,7 @@
         "stats",
         "stats4"
       ],
-      "Hash": "0df7d9f448796a41bd9a2717f38ebdd7"
+      "Hash": "ef6ff3e15ce624118e6cf8151e58e38c"
     },
     "ExploreModelMatrix": {
       "Package": "ExploreModelMatrix",
@@ -301,7 +302,7 @@
     },
     "GOSemSim": {
       "Package": "GOSemSim",
-      "Version": "2.26.0",
+      "Version": "2.26.1",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
@@ -311,11 +312,11 @@
         "methods",
         "utils"
       ],
-      "Hash": "778277977521173478410d03538b49dc"
+      "Hash": "b27837cc8c91273e45563693f1017221"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
-      "Version": "1.36.1",
+      "Version": "1.36.2",
       "Source": "Bioconductor",
       "Requirements": [
         "BiocGenerics",
@@ -329,7 +330,7 @@
         "stats4",
         "utils"
       ],
-      "Hash": "9e991e821a6d09eee85442a902a8c048"
+      "Hash": "94cae1161cc7a68e9e28a2a4994beb72"
     },
     "GenomeInfoDbData": {
       "Package": "GenomeInfoDbData",
@@ -452,11 +453,12 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.5-4.1",
+      "Version": "1.6-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
+        "grDevices",
         "graphics",
         "grid",
         "lattice",
@@ -464,17 +466,17 @@
         "stats",
         "utils"
       ],
-      "Hash": "38082d362d317745fb932e13956dccbb"
+      "Hash": "cb6855ac711958ca734b75e631b2035d"
     },
     "MatrixGenerics": {
       "Package": "MatrixGenerics",
-      "Version": "1.12.2",
+      "Version": "1.12.3",
       "Source": "Bioconductor",
       "Requirements": [
         "matrixStats",
         "methods"
       ],
-      "Hash": "62f2e21697e9aeed7bcb3f482ac25dd7"
+      "Hash": "10a6bd0dcabaeede87616e4465b6ac6f"
     },
     "R6": {
       "Package": "R6",
@@ -539,7 +541,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "0.12.4.1.0",
+      "Version": "0.12.6.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -549,7 +551,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "44b6ca3a6d22b4c87cdd6140e6f15245"
+      "Hash": "4a4fc9c9d0d24ee8708bb17528372f30"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -578,7 +580,7 @@
     },
     "S4Arrays": {
       "Package": "S4Arrays",
-      "Version": "1.0.4",
+      "Version": "1.0.6",
       "Source": "Bioconductor",
       "Requirements": [
         "BiocGenerics",
@@ -586,11 +588,12 @@
         "Matrix",
         "R",
         "S4Vectors",
+        "abind",
         "crayon",
         "methods",
         "stats"
       ],
-      "Hash": "3be34103255923c2fbb4a98b4d7449b9"
+      "Hash": "2b40d107b4a6fbd3f0cc81214d0b2891"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
@@ -645,9 +648,21 @@
       ],
       "Hash": "cc3048ef590a16ff55a5e3149d5e060b"
     },
+    "abind": {
+      "Package": "abind",
+      "Version": "1.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "utils"
+      ],
+      "Hash": "4f57884290cc75ab22f4af9e9d4ca862"
+    },
     "affy": {
       "Package": "affy",
-      "Version": "1.78.0",
+      "Version": "1.78.2",
       "Source": "Bioconductor",
       "Requirements": [
         "Biobase",
@@ -663,7 +678,7 @@
         "utils",
         "zlibbioc"
       ],
-      "Hash": "9fd6d425bffe512f423071022e2df98c"
+      "Hash": "8dc58f7e9086da714fbfcaf100b95304"
     },
     "affyio": {
       "Package": "affyio",
@@ -714,10 +729,11 @@
     },
     "aplot": {
       "Package": "aplot",
-      "Version": "0.1.10",
+      "Version": "0.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "R",
         "ggfun",
         "ggplot2",
         "ggplotify",
@@ -726,17 +742,17 @@
         "patchwork",
         "utils"
       ],
-      "Hash": "e5ce4f3b5fe236bb879712ff8f956f06"
+      "Hash": "391be0aec49261b94791f20cb863c0b7"
     },
     "askpass": {
       "Package": "askpass",
-      "Version": "1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "sys"
       ],
-      "Hash": "e8a22846fff485f0be3770c2da758713"
+      "Hash": "cad6cf7f1d5f6e906700b9d3e718c796"
     },
     "babelgene": {
       "Package": "babelgene",
@@ -836,7 +852,7 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.5.0",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -852,7 +868,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "1b117970533deb6d4e992c1b34e9d905"
+      "Hash": "283015ddfbb9d7bf15ea9f0b5698f0d9"
     },
     "caTools": {
       "Package": "caTools",
@@ -936,7 +952,7 @@
     },
     "clusterProfiler": {
       "Package": "clusterProfiler",
-      "Version": "4.8.1",
+      "Version": "4.8.3",
       "Source": "Bioconductor",
       "Requirements": [
         "AnnotationDbi",
@@ -958,7 +974,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "a49500a852fc1f99878d37294e5997c0"
+      "Hash": "358573de6d0ae89b2a9c27bb1f061898"
     },
     "coda": {
       "Package": "coda",
@@ -1021,10 +1037,13 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.4",
+      "Version": "0.4.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3f7d8664d7324406cd10cd650ad85e5f"
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "707fae4bbf73697ec8d85f9d7076c061"
     },
     "crayon": {
       "Package": "crayon",
@@ -1053,13 +1072,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.0.1",
+      "Version": "5.0.2",
       "Source": "Repository",
-      "Repository": "https://carpentries.r-universe.dev",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "2118af9cb164c8d2dddc7b89eaf732d9"
+      "Hash": "511bacbfa153a15251166b463b4da4f9"
     },
     "data.table": {
       "Package": "data.table",
@@ -1110,9 +1129,9 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "R6",
@@ -1129,7 +1148,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "dea6970ff715ca541c387de363ff405e"
+      "Hash": "e85ffbebaad5f70e1a2e2ef4302b4949"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -1158,14 +1177,8 @@
     },
     "enrichplot": {
       "Package": "enrichplot",
-      "Version": "1.20.0",
+      "Version": "1.20.1",
       "Source": "Bioconductor",
-      "RemoteType": "bioconductor",
-      "Remotes": "YuLab-SMU/tidydr",
-      "git_url": "https://git.bioconductor.org/packages/enrichplot",
-      "git_branch": "RELEASE_3_17",
-      "git_last_commit": "ae72efe",
-      "git_last_commit_date": "2023-04-25",
       "Requirements": [
         "DOSE",
         "GOSemSim",
@@ -1191,7 +1204,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "824abb25b3614c64f56dfa7a20d75af4"
+      "Hash": "2c3a0a3515aef213333b77104bcdf22a"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -1232,13 +1245,13 @@
     },
     "fastmatch": {
       "Package": "fastmatch",
-      "Version": "1.1-3",
+      "Version": "1.1-4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "dabc225759a2c2b241e60e42bf0e8e54"
+      "Hash": "8c406b7284bbaef08e01c6687367f195"
     },
     "fgsea": {
       "Package": "fgsea",
@@ -1263,7 +1276,7 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.1",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1271,7 +1284,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
+      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
     },
     "foreach": {
       "Package": "foreach",
@@ -1298,14 +1311,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.2",
+      "Version": "1.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "94af08e0aa9675a16fadbb3aaaa90d2a"
+      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
     },
     "futile.logger": {
       "Package": "futile.logger",
@@ -1372,16 +1385,17 @@
     },
     "ggfun": {
       "Package": "ggfun",
-      "Version": "0.1.1",
+      "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "R",
         "ggplot2",
         "grid",
         "rlang",
         "utils"
       ],
-      "Hash": "f31174df0168499f1aa33bc7f96bfc25"
+      "Hash": "068a90b74406f3abb0647635a2696880"
     },
     "ggnewscale": {
       "Package": "ggnewscale",
@@ -1395,9 +1409,9 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.2",
+      "Version": "3.4.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "MASS",
         "R",
@@ -1416,11 +1430,11 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
+      "Hash": "85846544c596e71f8f46483ab165da33"
     },
     "ggplotify": {
       "Package": "ggplotify",
-      "Version": "0.1.1",
+      "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1432,7 +1446,7 @@
         "gridGraphics",
         "yulab.utils"
       ],
-      "Hash": "788dcf9b28f7bbe339338093c3654109"
+      "Hash": "1547863db3b472cf7181973acf649f1a"
     },
     "ggraph": {
       "Package": "ggraph",
@@ -1483,14 +1497,8 @@
     },
     "ggtree": {
       "Package": "ggtree",
-      "Version": "3.8.0",
+      "Version": "3.8.2",
       "Source": "Bioconductor",
-      "RemoteType": "bioconductor",
-      "Remotes": "GuangchuangYu/treeio",
-      "git_url": "https://git.bioconductor.org/packages/ggtree",
-      "git_branch": "RELEASE_3_17",
-      "git_last_commit": "e7c9890",
-      "git_last_commit_date": "2023-04-25",
       "Requirements": [
         "R",
         "ape",
@@ -1512,7 +1520,7 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "1fb9abcc33dc8e6ed3ee8510230b631d"
+      "Hash": "8959d04f88a175de3f0cd2b46b4c2a65"
     },
     "glue": {
       "Package": "glue",
@@ -1596,7 +1604,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.3",
+      "Version": "0.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1607,7 +1615,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "b44addadb528a0d227794121c00572a0"
+      "Hash": "b29cf3031f49b04ab9c852c912547eef"
     },
     "gtools": {
       "Package": "gtools",
@@ -1663,7 +1671,7 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.5",
+      "Version": "0.5.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1676,7 +1684,7 @@
         "rlang",
         "utils"
       ],
-      "Hash": "ba0240784ad50a62165058a27459304a"
+      "Hash": "a2326a66919a3311f7fbb1e3bf568283"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
@@ -1710,7 +1718,7 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.6",
+      "Version": "1.4.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1721,11 +1729,11 @@
         "mime",
         "openssl"
       ],
-      "Hash": "7e5e3cbd2a7bc07880c94e22348fb661"
+      "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
     },
     "igraph": {
       "Package": "igraph",
-      "Version": "1.5.0",
+      "Version": "1.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1735,6 +1743,7 @@
         "cpp11",
         "grDevices",
         "graphics",
+        "lifecycle",
         "magrittr",
         "methods",
         "pkgconfig",
@@ -1742,7 +1751,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "84818361421d5fc3ff0bf4e669524217"
+      "Hash": "80401cb5ec513e8ddc56764d03f63669"
     },
     "isoband": {
       "Package": "isoband",
@@ -1804,14 +1813,14 @@
     },
     "labeling": {
       "Package": "labeling",
-      "Version": "0.4.2",
+      "Version": "0.4.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "graphics",
         "stats"
       ],
-      "Hash": "3d5108641f47470611a32d0bdf357a72"
+      "Hash": "b64ec208ac5bc1852b285f665d6368b3"
     },
     "lambda.r": {
       "Package": "lambda.r",
@@ -1931,7 +1940,7 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.8-42",
+      "Version": "1.9-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1944,7 +1953,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "3460beba7ccc8946249ba35327ba902a"
+      "Hash": "086028ca0460d0c368028d3bda58f31b"
     },
     "microbenchmark": {
       "Package": "microbenchmark",
@@ -1996,18 +2005,18 @@
     },
     "mvtnorm": {
       "Package": "mvtnorm",
-      "Version": "1.2-2",
+      "Version": "1.2-3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "ef6270cb713747aa8211620d6a47188d"
+      "Hash": "463b268710930f7bffef33147400966a"
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-162",
+      "Version": "3.1-163",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2017,7 +2026,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
+      "Hash": "8d1938040a05566f4f7a14af4feadd6b"
     },
     "numDeriv": {
       "Package": "numDeriv",
@@ -2031,13 +2040,13 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.0.6",
+      "Version": "2.1.0",
       "Source": "Repository",
-      "Repository": "https://carpentries.r-universe.dev",
+      "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "0f7cd2962e3044bb940cca4f4b5cecbe"
+      "Hash": "273a6bb4a9844c296a459d2176673270"
     },
     "org.Hs.eg.db": {
       "Package": "org.Hs.eg.db",
@@ -2063,19 +2072,21 @@
     },
     "patchwork": {
       "Package": "patchwork",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
+        "cli",
         "ggplot2",
         "grDevices",
         "graphics",
         "grid",
         "gtable",
+        "rlang",
         "stats",
         "utils"
       ],
-      "Hash": "63b611e9d909a9ed057639d9c3b77152"
+      "Hash": "c5754106c02e8e019941100c81149431"
     },
     "pillar": {
       "Package": "pillar",
@@ -2153,22 +2164,23 @@
     },
     "promises": {
       "Package": "promises",
-      "Version": "1.2.0.1",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R6",
         "Rcpp",
+        "fastmap",
         "later",
         "magrittr",
         "rlang",
         "stats"
       ],
-      "Hash": "4ab2c43adb4d4699cf3690acd378d75d"
+      "Hash": "0d8a15c9d000970ada1ab21405387dee"
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.0.1",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2179,7 +2191,7 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "d71c815267c640f17ddbf7f16144b4bb"
+      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
     },
     "qvalue": {
       "Package": "qvalue",
@@ -2206,13 +2218,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.17.3",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "4543b8cd233ae25c6aba8548be9e747e"
+      "Hash": "4b22ac016fe54028b88d0c68badbd061"
     },
     "reshape2": {
       "Package": "reshape2",
@@ -2262,7 +2274,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.23",
+      "Version": "2.24",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2282,11 +2294,11 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "79f14e53725f28900d936f692bfdd69f"
+      "Hash": "3854c37590717c08c32ec8542a2e0a35"
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.6",
+      "Version": "0.4.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2296,7 +2308,7 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "cc3ec7dd33982ef56570229b62d6388e"
+      "Hash": "6bd4d33b50ff927191ec9acbf52fd056"
     },
     "scales": {
       "Package": "scales",
@@ -2362,7 +2374,7 @@
     },
     "shiny": {
       "Package": "shiny",
-      "Version": "1.7.4.1",
+      "Version": "1.7.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2392,7 +2404,7 @@
         "withr",
         "xtable"
       ],
-      "Hash": "f7f201522eedbc95f10ef323b100ff29"
+      "Hash": "438b99792adbe82a8329ad8697d45afe"
     },
     "shinydashboard": {
       "Package": "shinydashboard",
@@ -2572,7 +2584,7 @@
     },
     "tidytree": {
       "Package": "tidytree",
-      "Version": "0.4.2",
+      "Version": "0.4.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2590,21 +2602,21 @@
         "tidyselect",
         "yulab.utils"
       ],
-      "Hash": "6f2eb34d95db945d4dd022b0811e28db"
+      "Hash": "b6c0b32b3632419e1a91bf4e0c4f7337"
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.45",
+      "Version": "0.46",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "e4e357f28c2edff493936b6cb30c3d65"
+      "Hash": "0c41a73214d982f539c56a7773c7afa5"
     },
     "treeio": {
       "Package": "treeio",
-      "Version": "1.24.1",
+      "Version": "1.24.3",
       "Source": "Bioconductor",
       "Requirements": [
         "R",
@@ -2619,7 +2631,7 @@
         "tidytree",
         "utils"
       ],
-      "Hash": "cd8ffe516f3d1a25f291847dc32e4cd1"
+      "Hash": "c8c8efbcec2f1512d6079af62b0f112b"
     },
     "tweenr": {
       "Package": "tweenr",
@@ -2662,7 +2674,7 @@
     },
     "viridis": {
       "Package": "viridis",
-      "Version": "0.6.3",
+      "Version": "0.6.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2671,7 +2683,7 @@
         "gridExtra",
         "viridisLite"
       ],
-      "Hash": "0d774f552202add033efc43a30293b3f"
+      "Hash": "80cd127bc8c9d3d9f0904ead9a9102f1"
     },
     "viridisLite": {
       "Package": "viridisLite",
@@ -2713,14 +2725,14 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.39",
+      "Version": "0.40",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "stats",
         "tools"
       ],
-      "Hash": "8f56e9acb54fb525e66464d57ab58bcb"
+      "Hash": "be07d23211245fc7d4209f54c4e4ffc8"
     },
     "xtable": {
       "Package": "xtable",
@@ -2743,14 +2755,16 @@
     },
     "yulab.utils": {
       "Package": "yulab.utils",
-      "Version": "0.0.6",
+      "Version": "0.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "memoise",
+        "rlang",
         "stats",
         "utils"
       ],
-      "Hash": "0d0b7cc6da5efc21f07f6b8d966a9cc1"
+      "Hash": "2435cde407c69abd057343ab6ce386d0"
     },
     "zlibbioc": {
       "Package": "zlibbioc",


### PR DESCRIPTION
I've run the package update manually because the automated workflow was having trouble after the release of {renv} 1.0.0.

This brings in updates to 50 packages. Please wait for the output to run and then check for any new errors, warnings or surprising output changes.

I ran the following commands to update the cache with {renv} 1.0.2

```r
sandpaper::manage_deps()
sandpaper::update_cache()
```


```
- 50 packages have updates available.

# BioCsoft -------------------------------------------------------------------
- affy              [1.78.0 -> 1.78.2]
- clusterProfiler   [4.8.1 -> 4.8.3]
- DelayedArray      [0.26.6 -> 0.26.7]
- enrichplot        [1.20.0 -> 1.20.1]
- GenomeInfoDb      [1.36.1 -> 1.36.2]
- ggtree            [3.8.0 -> 3.8.2]
- GOSemSim          [2.26.0 -> 2.26.1]
- MatrixGenerics    [1.12.2 -> 1.12.3]
- S4Arrays          [1.0.4 -> 1.0.6]
- treeio            [1.24.1 -> 1.24.3]

# CRAN -----------------------------------------------------------------------
- aplot             [0.1.10 -> 0.2.0]
- askpass           [1.1 -> 1.2.0]
- BiocManager       [1.30.21 -> 1.30.22]
- boot              [1.3-28 -> 1.3-28.1]
- bslib             [repo: RSPM -> CRAN; ver: 0.5.0 -> 0.5.1]
- cpp11             [repo: RSPM -> CRAN; ver: 0.4.4 -> 0.4.6]
- curl              [repo: RSPM -> CRAN; ver: 5.0.1 -> 5.0.2]
- dplyr             [1.1.2 -> 1.1.3]
- DT                [0.28 -> 0.29]
- fastmatch         [1.1-3 -> 1.1-4]
- fontawesome       [0.5.1 -> 0.5.2]
- foreign           [0.8-82 -> 0.8-84]
- fs                [1.6.2 -> 1.6.3]
- ggfun             [0.1.1 -> 0.1.2]
- ggplot2           [3.4.2 -> 3.4.3]
- ggplotify         [0.1.1 -> 0.1.2]
- gtable            [0.3.3 -> 0.3.4]
- htmltools         [repo: RSPM -> CRAN; ver: 0.5.5 -> 0.5.6]
- httr              [1.4.6 -> 1.4.7]
- igraph            [1.5.0 -> 1.5.1]
- labeling          [0.4.2 -> 0.4.3]
- Matrix            [1.5-4.1 -> 1.6-1]
- mgcv              [1.8-42 -> 1.9-0]
- mvtnorm           [1.2-2 -> 1.2-3]
- nlme              [3.1-162 -> 3.1-163]
- openssl           [2.0.6 -> 2.1.0]
- patchwork         [1.1.2 -> 1.1.3]
- promises          [repo: RSPM -> CRAN; ver: 1.2.0.1 -> 1.2.1]
- purrr             [repo: RSPM -> CRAN; ver: 1.0.1 -> 1.0.2]
- RcppArmadillo     [0.12.4.1.0 -> 0.12.6.3.0]
- renv              [0.17.3 -> 1.0.2]
- rmarkdown         [repo: RSPM -> CRAN; ver: 2.23 -> 2.24]
- sass              [0.4.6 -> 0.4.7]
- shiny             [1.7.4.1 -> 1.7.5]
- survival          [3.5-5 -> 3.5-7]
- tidytree          [0.4.2 -> 0.4.5]
- tinytex           [0.45 -> 0.46]
- viridis           [0.6.3 -> 0.6.4]
- xfun              [0.39 -> 0.40]
- yulab.utils       [0.0.6 -> 0.0.9]
```
